### PR TITLE
feat: VM-DC-code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local .terraform directories
 .terraform/
+.terraform.lock.hcl
 
 # .tfstate files
 *.tfstate

--- a/az-iac-back/mod_virtual_machine_windows/main.tf
+++ b/az-iac-back/mod_virtual_machine_windows/main.tf
@@ -7,7 +7,10 @@ resource "azurerm_windows_virtual_machine" "wvm" {
   proximity_placement_group_id = var.proximity_placement_group_id
   admin_username      = var.admin_username
   admin_password      = var.admin_password
-  
+
+  patch_mode = (var.source_image_reference_sku == "2025-datacenter-azure-edition" || var.source_image_reference_sku == "2022-datacenter-azure-edition-hotpatch") ? "AutomaticByPlatform" : null
+  hotpatching_enabled = false
+
   os_disk {
     caching              = var.os_disk_caching
     storage_account_type = var.os_disk_storage_account_type

--- a/az-iac-back/mod_virtual_machine_windows/variables.tf
+++ b/az-iac-back/mod_virtual_machine_windows/variables.tf
@@ -58,10 +58,10 @@ variable "source_image_reference_version" {
   type        = string
 }
 
-variable "computer_name" {
-  description = "computer_name"
-  type        = string
-}
+#variable "computer_name" {
+#  description = "computer_name"
+#  type        = string
+#}
 
 variable "admin_username" {
   description = "admin_username"
@@ -73,10 +73,10 @@ variable "admin_password" {
   type        = string
 }
 
-variable "storage_account_uri" {
-  description = "storage_account_uri"
-  type        = string
-}
+#variable "storage_account_uri" {
+#  description = "storage_account_uri"
+#  type        = string
+#}
 
 variable "tags" {
   description = "tags"

--- a/az-iac-front/rgppscldc001/backend.tf
+++ b/az-iac-front/rgppscldc001/backend.tf
@@ -1,39 +1,9 @@
-/*
-State Naming Convention Documentation
-
-This file defines the naming convention for Terraform state files used in this project.
-
-Naming Pattern:
-  <csp>.<IAC_Language>.<environment>.<Project|Bussiness>.<Resource_Abbreviation>.<resource_group_name>.<state>
-
-Where:
-  - <csp>: Cloud Service Provider (e.g., Azure, AWS, GCP)
-  - <IAC_Language>: Infrastructure as Code language (e.g., Terraform)
-  - <environment>: Deployment environment (e.g., Test, QA, Prod)
-  - <Project|Bussiness>: Name of the project or business unit (e.g., fani, lsc, murex)
-  - <Resource_Abbreviation>: Resource Abbreviation (e.g., rg, vnet, vm)
-  - <Resource_Name>: Name of the resource.
-  - <state>: State file extension.
-
-Variables:
-  - <csp>
-  - <environment>
-  - <Project|Bussiness>
-  - <Resource_Abbreviation>
-  - <Resource_Name>
-  - <resource_group_name>
-
-Constants:
-  - <IAC_Language>
-  - <state>
-*/
-
 terraform {
   backend "azurerm" {
-    subscription_id      = "fb591a13-981e-4a6f-a106-de39db876fdc"
-    resource_group_name  = "rg-pp-scl-tfstate-001"
-    storage_account_name = "stppscltfstate001"
-    container_name       = "tfstates"
+    subscription_id      = "67e8f9c1-a3d9-405e-b72d-43e7c16a46d3"
+    resource_group_name  = "AR-TFstate"
+    storage_account_name = "sttf1727848146"
+    container_name       = "slopted-tfstate"
     key                  = "azure.terraform.pp.ldz.rg.rg-pp-scl-dc-001.state"
   }
 }

--- a/az-iac-front/rgppscldc001/main.tf
+++ b/az-iac-front/rgppscldc001/main.tf
@@ -1,5 +1,5 @@
 module "rg-pp-scl-dc-001" {
-  source   = "git::https://github.com/bch-devsecops/az-iac-back.git//mod_resource_group?ref=master"
+  source   = "git::https://github.com/slopted/BCH_IAC//az-iac-back/mod_resource_group?ref=main"
   name     = "rg-pp-scl-dc-001"
   location = "chilecentral"
 }

--- a/az-iac-front/vnetdcppscl001/backend.tf
+++ b/az-iac-front/vnetdcppscl001/backend.tf
@@ -1,39 +1,9 @@
-/*
-State Naming Convention Documentation
-
-This file defines the naming convention for Terraform state files used in this project.
-
-Naming Pattern:
-  <csp>.<IAC_Language>.<environment>.<Project|Bussiness>.<Resource_Abbreviation>.<resource_group_name>.<state>
-
-Where:
-  - <csp>: Cloud Service Provider (e.g., Azure, AWS, GCP)
-  - <IAC_Language>: Infrastructure as Code language (e.g., Terraform)
-  - <environment>: Deployment environment (e.g., Test, QA, Prod)
-  - <Project|Bussiness>: Name of the project or business unit (e.g., fani, lsc, murex)
-  - <Resource_Abbreviation>: Resource Abbreviation (e.g., rg, vnet, vm)
-  - <Resource_Name>: Name of the resource.
-  - <state>: State file extension.
-
-Variables:
-  - <csp>
-  - <environment>
-  - <Project|Bussiness>
-  - <Resource_Abbreviation>
-  - <Resource_Name>
-  - <resource_group_name>
-
-Constants:
-  - <IAC_Language>
-  - <state>
-*/
-
 terraform {
   backend "azurerm" {
-    subscription_id      = "fb591a13-981e-4a6f-a106-de39db876fdc"
-    resource_group_name  = "rg-pp-scl-tfstate-001"
-    storage_account_name = "stppscltfstate001"
-    container_name       = "tfstates"
+    subscription_id      = "67e8f9c1-a3d9-405e-b72d-43e7c16a46d3"
+    resource_group_name  = "AR-TFstate"
+    storage_account_name = "sttf1727848146"
+    container_name       = "slopted-tfstate"
     key                  = "azure.terraform.pp.ldz.vnet.vnet-dcpp-scl-001.state"
   }
 }

--- a/az-iac-front/vnetdcppscl001/main.tf
+++ b/az-iac-front/vnetdcppscl001/main.tf
@@ -1,5 +1,5 @@
 module "vnet-dcpp-scl-001" {
-  source   = "git::https://github.com/bch-devsecops/az-iac-back.git//mod_virtual_network"
+  source   = "git::https://github.com/slopted/BCH_IAC//az-iac-back/mod_virtual_network?ref=main"
   name     = "vnet-dcpp-scl-001"
   resource_group_location = data.azurerm_resource_group.rg-pp-scl-dc-001.location
   resource_group_name = data.azurerm_resource_group.rg-pp-scl-dc-001.name
@@ -11,7 +11,7 @@ module "vnet-dcpp-scl-001" {
 # ===========================
 
 module "snet-dcpp-addc-001" {
-  source   = "git::https://github.com/bch-devsecops/az-iac-back.git//mod_subnet"
+  source   = "git::https://github.com/slopted/BCH_IAC//az-iac-back/mod_subnet?ref=main"
   depends_on = [ module.vnet-dcpp-scl-001 ]
   name     = "snet-dcpp-addc-001"
   resource_group_name = data.azurerm_resource_group.rg-pp-scl-dc-001.name

--- a/az-iac-front/wsclppazuvmdc01/backend.tf
+++ b/az-iac-front/wsclppazuvmdc01/backend.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "azurerm" {    
-    subscription_id      = "fb591a13-981e-4a6f-a106-de39db876fdc"
-    resource_group_name  = "rg-pp-scl-tfstate-001"
-    storage_account_name = "stppscltfstate001"
-    container_name       = "tfstates"
-    key                  = "azure.terraform.prod.ldz.vm.wsclppazuvmdc01.state"
+    subscription_id      = "67e8f9c1-a3d9-405e-b72d-43e7c16a46d3"
+    resource_group_name  = "AR-TFstate"
+    storage_account_name = "sttf1727848146"
+    container_name       = "slopted-tfstate"
+    key                  = "azure.terraform.pp.ldz.vm.wsclppazuvmdc01.state"
   }
 }

--- a/az-iac-front/wsclppazuvmdc01/main.tf
+++ b/az-iac-front/wsclppazuvmdc01/main.tf
@@ -1,5 +1,5 @@
 module "nsg-nic-wsclppazuvmdc01" {
-  source              = "git::https://github.com/bch-devsecops/az-iac-back.git//mod_network_security_group?ref=master"
+  source              = "git::https://github.com/slopted/BCH_IAC//az-iac-back/mod_network_security_group?ref=main"
   name                = "nsg-nic-wsclppazuvmdc01"
   location            = "chilecentral"
   resource_group_name = data.azurerm_resource_group.rg-pp-scl-dc-001.name
@@ -7,7 +7,7 @@ module "nsg-nic-wsclppazuvmdc01" {
 
 module "nic-wsclppazuvmdc01" {
   depends_on                      = [module.nsg-nic-wsclppazuvmdc01]
-  source                         = "git::https://github.com/bch-devsecops/az-iac-back.git//mod_network_interface?ref=master"
+  source                         = "git::https://github.com/slopted/BCH_IAC//az-iac-back/mod_network_interface?ref=main"
   name                           = "nic-wsclppazuvmdc01"
   location                       = "chilecentral"
   resource_group_name            = data.azurerm_resource_group.rg-pp-scl-dc-001.name
@@ -19,7 +19,7 @@ module "nic-wsclppazuvmdc01" {
 
 module "wsclppazuvmdc01" {
   depends_on                         = [module.nic-wsclppazuvmdc01]
-  source                             = "git::https://github.com/bch-devsecops/az-iac-back.git//mod_virtual_machine_windows?ref=master"
+  source                             = "git::https://github.com/slopted/BCH_IAC//az-iac-back/mod_virtual_machine_windows?ref=main"
   name                               = "wsclppazuvmdc01"
   location                           = "chilecentral"
   resource_group_name                = data.azurerm_resource_group.rg-pp-scl-dc-001.name


### PR DESCRIPTION
This pull request updates several Terraform modules and backend configurations to point to new repository locations and state storage resources. It also introduces conditional configuration for Windows VM patching and comments out some unused variables. The main themes are repository migration, backend/state management updates, and Windows VM configuration improvements.

**Repository migration and module source updates:**

* Updated all module sources in `main.tf` files to point to the new repository (`slopted/BCH_IAC`) on the `main` branch instead of the previous `bch-devsecops/az-iac-back` repository on `master`. This affects resource group, virtual network, subnet, network security group, network interface, and Windows VM modules (`az-iac-front/rgppscldc001/main.tf`, `az-iac-front/vnetdcppscl001/main.tf`, `az-iac-front/wsclppazuvmdc01/main.tf`). [[1]](diffhunk://#diff-fc9e8344614da3ddb0ed3909d90e50b0f49c9653333237bb8fa15fc55820bc91L2-R2) [[2]](diffhunk://#diff-fd4d27a11a7f35f482e1cdf1fa3166d3bc64ea9c1cd2feb5ea1c4e3ce58202fdL2-R2) [[3]](diffhunk://#diff-fd4d27a11a7f35f482e1cdf1fa3166d3bc64ea9c1cd2feb5ea1c4e3ce58202fdL14-R14) [[4]](diffhunk://#diff-cf73da57a6c82aa66c9c9c22eb124a407ebb659cd41d9dc3e01d0aba336a3189L2-R10) [[5]](diffhunk://#diff-cf73da57a6c82aa66c9c9c22eb124a407ebb659cd41d9dc3e01d0aba336a3189L22-R22)

**Backend and state management:**

* Changed backend configuration in multiple `backend.tf` files to use a new Azure subscription, resource group, storage account, and container for Terraform state storage (`az-iac-front/rgppscldc001/backend.tf`, `az-iac-front/vnetdcppscl001/backend.tf`, `az-iac-front/wsclppazuvmdc01/backend.tf`). Also removed in-file documentation about state naming conventions. [[1]](diffhunk://#diff-ef3c7574231c0445d7dff95d14d1d8526a989d1471823af8444f6a59d037d5faL1-R6) [[2]](diffhunk://#diff-cd315eb66200075bdcf1a39abb81ca0c223a038bee258b94e50702124934d924L1-R6) [[3]](diffhunk://#diff-14747802b04b188f91ae5bced402c2c87ddb5cb8cc1718de4d8da21d39f6b222L3-R7)

**Windows VM configuration improvements:**

* Added conditional logic for `patch_mode` and set `hotpatching_enabled` to `false` in the Windows VM resource, enabling automatic patching for specific image SKUs (`az-iac-back/mod_virtual_machine_windows/main.tf`).

**Variable management:**

* Commented out unused variables `computer_name` and `storage_account_uri` in the Windows VM module to clean up the variable definitions (`az-iac-back/mod_virtual_machine_windows/variables.tf`). [[1]](diffhunk://#diff-6340c5659178c31445d13203f56dc7815bcea62cc052c58abe3f5eb2b4c014b0L61-R64) [[2]](diffhunk://#diff-6340c5659178c31445d13203f56dc7815bcea62cc052c58abe3f5eb2b4c014b0L76-R79)