### PR TITLE
bugfix: VM-DC-module

### DIFF
--- a/az-iac-back/mod_virtual_machine_windows/variables.tf
+++ b/az-iac-back/mod_virtual_machine_windows/variables.tf
@@ -4,7 +4,6 @@
 variable "ip_configuration" {
   description = "IP configuration for the virtual machine's network interface"
   type = object({
-    name                          = string
     subnet_id                     = string
     private_ip_address_allocation = optional(string, "Dynamic")
     private_ip_address            = optional(string)


### PR DESCRIPTION
This pull request makes a minor change to the `ip_configuration` variable definition in `mod_virtual_machine_windows/variables.tf` by removing the unused `name` field from the object type.