### PR TITLE
feat: Patch_mode update

### DIFF
--- a/az-iac-back/mod_virtual_machine_windows/main.tf
+++ b/az-iac-back/mod_virtual_machine_windows/main.tf
@@ -30,22 +30,14 @@ resource "azurerm_windows_virtual_machine" "wvm" {
     "2022-datacenter-azure-edition-core",
     "2022-datacenter-azure-edition-core-smalldisk",
     "2022-datacenter-azure-edition-hotpatch",
-    "2022-datacenter-azure-edition-hotpatch-smalldisk",
-    "2025-datacenter-azure-edition",
-    "2025-datacenter-azure-edition-smalldisk",
-    "2025-datacenter-azure-edition-core",
-    "2025-datacenter-azure-edition-core-smalldisk"
+    "2022-datacenter-azure-edition-hotpatch-smalldisk"
   ], lower(var.source_image_reference.sku)) ? "AutomaticByPlatform" : var.patch_mode
 
   hotpatching_enabled = contains([
     "2022-datacenter-azure-edition-core",
     "2022-datacenter-azure-edition-core-smalldisk",
     "2022-datacenter-azure-edition-hotpatch",
-    "2022-datacenter-azure-edition-hotpatch-smalldisk",
-    "2025-datacenter-azure-edition",
-    "2025-datacenter-azure-edition-smalldisk",
-    "2025-datacenter-azure-edition-core",
-    "2025-datacenter-azure-edition-core-smalldisk"
+    "2022-datacenter-azure-edition-hotpatch-smalldisk"
   ], lower(var.source_image_reference.sku)) ? true : var.hotpatching_enabled
 
   os_disk {


### PR DESCRIPTION
This pull request makes a small update to the list of supported Windows image SKUs for patch mode and hotpatching in the `az-iac-back/mod_virtual_machine_windows/main.tf` module. Specifically, it removes all references to "2025" Windows Server SKUs from the relevant lists, restricting support to only "2022" SKUs.

- Removed all "2025-datacenter-azure-edition" SKUs from the `patch_mode` and `hotpatching_enabled` logic in `az-iac-back/mod_virtual_machine_windows/main.tf`